### PR TITLE
[xmake] Normalize static option; skip default includes (#227)

### DIFF
--- a/xmake/option.lua
+++ b/xmake/option.lua
@@ -130,7 +130,7 @@ option("static", function()
         "The static flag is used to enable static linking of libraries instead of dynamic linking and use lld when linking",
         "static linking is disable by default"
     )
-    set_default(true)
+    set_default(false)
 end)
 
 option("use-llvm-compiler", function()

--- a/xmake/platform/bsd.lua
+++ b/xmake/platform/bsd.lua
@@ -27,6 +27,7 @@ function bsd_target()
     end
 
     local static_link = get_config("static")
+    static_link = static_link == true or static_link == "y" or static_link == "yes" or static_link == "true" or static_link == "on" or static_link == "1"
     if static_link then	
         add_ldflags("-static", {force = true})
     end

--- a/xmake/platform/cygwin.lua
+++ b/xmake/platform/cygwin.lua
@@ -1,4 +1,4 @@
-﻿if is_plat("cygwin") then
+if is_plat("cygwin") then
     -- Limited to i686, extended instruction set via march settings
     set_allowedarchs("x86_64", "i686", "aarch64", "arm", "arm64ec")
 end
@@ -43,6 +43,7 @@ function cygwin_target()
     end
 
     local static_link = get_config("static")
+    static_link = static_link == true or static_link == "y" or static_link == "yes" or static_link == "true" or static_link == "on" or static_link == "1"
     if static_link then	
         add_ldflags("-static", {force = true})
     end

--- a/xmake/platform/darwin.lua
+++ b/xmake/platform/darwin.lua
@@ -32,6 +32,7 @@ function darwin_target()
     end
 
     local static_link = get_config("static")
+    static_link = static_link == true or static_link == "y" or static_link == "yes" or static_link == "true" or static_link == "on" or static_link == "1"
     if static_link then	
         add_ldflags("-static", {force = true})
     end

--- a/xmake/platform/djgpp.lua
+++ b/xmake/platform/djgpp.lua
@@ -45,6 +45,7 @@ function djgpp_target()
     end
 
     local static_link = get_config("static")
+    static_link = static_link == true or static_link == "y" or static_link == "yes" or static_link == "true" or static_link == "on" or static_link == "1"
     if static_link then	
         add_ldflags("-static", {force = true})
     end

--- a/xmake/platform/linux.lua
+++ b/xmake/platform/linux.lua
@@ -28,6 +28,7 @@ function linux_target()
     end
 
     local static_link = get_config("static")
+    static_link = static_link == true or static_link == "y" or static_link == "yes" or static_link == "true" or static_link == "on" or static_link == "1"
     if static_link then	
         add_ldflags("-static", {force = true})
     end

--- a/xmake/platform/mingw.lua
+++ b/xmake/platform/mingw.lua
@@ -44,6 +44,7 @@ function mingw_target()
     end
 
     local static_link = get_config("static")
+    static_link = static_link == true or static_link == "y" or static_link == "yes" or static_link == "true" or static_link == "on" or static_link == "1"
     if static_link then	
         add_ldflags("-static", {force = true})
     end

--- a/xmake/platform/none.lua
+++ b/xmake/platform/none.lua
@@ -35,6 +35,7 @@ function none_target()
     end
 
     local static_link = get_config("static")
+    static_link = static_link == true or static_link == "y" or static_link == "yes" or static_link == "true" or static_link == "on" or static_link == "1"
     if static_link then	
         add_ldflags("-static", {force = true})
     end

--- a/xmake/platform/wasm-emscripten.lua
+++ b/xmake/platform/wasm-emscripten.lua
@@ -30,6 +30,7 @@ function wasm_emscripten_target()
     end
 
     local static_link = get_config("static")
+    static_link = static_link == true or static_link == "y" or static_link == "yes" or static_link == "true" or static_link == "on" or static_link == "1"
     if static_link then	
         add_ldflags("-static", {force = true})
     end

--- a/xmake/platform/wasm-wasi.lua
+++ b/xmake/platform/wasm-wasi.lua
@@ -30,6 +30,7 @@ function wasm_wasi_target()
     end
 
     local static_link = get_config("static")
+    static_link = static_link == true or static_link == "y" or static_link == "yes" or static_link == "true" or static_link == "on" or static_link == "1"
     if static_link then	
         add_ldflags("-static", {force = true})
     end

--- a/xmake/platform/windows.lua
+++ b/xmake/platform/windows.lua
@@ -30,6 +30,7 @@ function windows_target()
         end
         
         local static_link = get_config("static")
+        static_link = static_link == true or static_link == "y" or static_link == "yes" or static_link == "true" or static_link == "on" or static_link == "1"
 
         if is_mode("debug") then    
             if static_link then	
@@ -94,6 +95,7 @@ function windows_target()
         add_cxflags("-GR-") -- disable rtti
     
         local static_link = get_config("static")
+        static_link = static_link == true or static_link == "y" or static_link == "yes" or static_link == "true" or static_link == "on" or static_link == "1"
     
         if is_mode("debug") then
             add_cxflags("-GS") -- enable buffer overflow check

--- a/xmake/utility/common.lua
+++ b/xmake/utility/common.lua
@@ -28,3 +28,27 @@ function update_cache(cache_info)
     detectcache:set(cache_key, cache_info)
     detectcache:save()
 end
+
+---Get a normalized boolean config value
+---@param name string --Config name
+---@param default boolean | nil --Default value when config is unset
+---@return boolean --Normalized boolean value
+function get_config_bool(name, default)
+    local value = get_config(name)
+    if value == nil then
+        return default == true
+    end
+    if type(value) == "boolean" then
+        return value
+    end
+    if type(value) == "string" then
+        local normalized = string.lower(string.trim(value))
+        if normalized == "y" or normalized == "yes" or normalized == "true" or normalized == "on" or normalized == "1" then
+            return true
+        end
+        if normalized == "n" or normalized == "no" or normalized == "false" or normalized == "off" or normalized == "0" then
+            return false
+        end
+    end
+    return value and true or false
+end

--- a/xmake/utility/utility.lua
+++ b/xmake/utility/utility.lua
@@ -76,6 +76,11 @@ local function _normalize_dir(dir)
     return os.isdir(dir) and path.normalize(dir) or dir
 end
 
+local function _is_default_system_include_dir(dir)
+    local normalized = _normalize_dir(dir)
+    return normalized == "/usr/include" or normalized == "/usr/local/include"
+end
+
 local function _is_library_path(flag)
     if not flag or flag == "" or not flag:find("[/\\]") then
         return false
@@ -102,14 +107,20 @@ local function _parse_llvm_cxxflags(flags, result, seen)
             value, consumed = _extract_prefixed_value(argv, i, "/I")
         end
         if value then
-            _append_unique(result, seen, "sysincludedirs", _normalize_dir(value))
+            local include_dir = _normalize_dir(value)
+            if not _is_default_system_include_dir(include_dir) then
+                _append_unique(result, seen, "sysincludedirs", include_dir)
+            end
             i = i + 1 + consumed
             goto continue
         end
 
         value, consumed = _extract_prefixed_value(argv, i, "-isystem")
         if value then
-            _append_unique(result, seen, "sysincludedirs", _normalize_dir(value))
+            local include_dir = _normalize_dir(value)
+            if not _is_default_system_include_dir(include_dir) then
+                _append_unique(result, seen, "sysincludedirs", include_dir)
+            end
             i = i + 1 + consumed
             goto continue
         end
@@ -366,7 +377,10 @@ function get_llvm_jit_options()
     }
     local seen = {}
 
-    _append_unique(result, seen, "includedirs", _normalize_dir(includedir))
+    local normalized_includedir = _normalize_dir(includedir)
+    if not _is_default_system_include_dir(normalized_includedir) then
+        _append_unique(result, seen, "includedirs", normalized_includedir)
+    end
     _append_unique(result, seen, "linkdirs", _normalize_dir(libdir))
     _parse_llvm_cxxflags(cxxflags, result, seen)
     _parse_llvm_linkflags(system_libs, result, seen, "syslinks")


### PR DESCRIPTION
Set the "static" option default to false and normalize config values in platform scripts to accept common truthy string forms. Add a get_config_bool helper and use normalized checks to control adding the -static ldflag. Omit /usr/include and /usr/local/include from parsed LLVM include lists to avoid redundant default includes.