### PR TITLE
[llvm-jit] Refactor string handling and improve type consistency (#229)

### DIFF
--- a/src/uwvm2/runtime/compiler/llvm_jit/compile_all_from_uwvm/translate.cppm
+++ b/src/uwvm2/runtime/compiler/llvm_jit/compile_all_from_uwvm/translate.cppm
@@ -27,7 +27,6 @@ module;
 # include <cstdint>
 # include <limits>
 # include <memory>
-# include <string>
 # include <utility>
 // macro
 # include <uwvm2/utils/macro/push_macros.h>

--- a/src/uwvm2/runtime/compiler/llvm_jit/compile_all_from_uwvm/translate.h
+++ b/src/uwvm2/runtime/compiler/llvm_jit/compile_all_from_uwvm/translate.h
@@ -28,7 +28,6 @@
 # include <cstdint>
 # include <limits>
 # include <memory>
-# include <string>
 # include <utility>
 // macro
 # include <uwvm2/utils/macro/push_macros.h>

--- a/src/uwvm2/runtime/compiler/llvm_jit/compile_all_from_uwvm/translate/single_func.h
+++ b/src/uwvm2/runtime/compiler/llvm_jit/compile_all_from_uwvm/translate/single_func.h
@@ -1177,16 +1177,16 @@ namespace details
         {
             if(task_module_storage.llvm_context_holder == nullptr || task_module_storage.llvm_module == nullptr) [[unlikely]] { return false; }
 
-            ::std::string serialized_bitcode{};
+            ::uwvm2::utils::container::string serialized_bitcode{};
             {
                 // Reparse each fragment into the merged context before linking. Direct
                 // cross-context linking hit unstable intrinsic remangling on this toolchain.
-                ::llvm::raw_string_ostream bitcode_stream(serialized_bitcode);
+                raw_uwvm_string_ostream bitcode_stream(serialized_bitcode);
                 ::llvm::WriteBitcodeToFile(*task_module_storage.llvm_module, bitcode_stream);
             }
 
             auto parsed_task_module_expected{
-                ::llvm::parseBitcodeFile(::llvm::MemoryBufferRef(serialized_bitcode, task_module_storage.llvm_module->getModuleIdentifier()),
+                ::llvm::parseBitcodeFile(::llvm::MemoryBufferRef(get_llvm_string_ref(serialized_bitcode), task_module_storage.llvm_module->getName()),
                                          merged_llvm_context)};
             if(!parsed_task_module_expected) [[unlikely]]
             {

--- a/src/uwvm2/runtime/compiler/llvm_jit/compile_all_from_uwvm/translate/single_func_emit.h
+++ b/src/uwvm2/runtime/compiler/llvm_jit/compile_all_from_uwvm/translate/single_func_emit.h
@@ -45,6 +45,26 @@ struct llvm_jit_memory_snapshot_values_t
     ::llvm::Value* byte_length{};
 };
 
+[[nodiscard]] inline ::llvm::StringRef get_llvm_string_ref(::uwvm2::utils::container::string_view str) noexcept
+{ return ::llvm::StringRef{str.data(), str.size()}; }
+
+[[nodiscard]] inline ::llvm::StringRef get_llvm_string_ref(::uwvm2::utils::container::string const& str) noexcept
+{ return get_llvm_string_ref(::uwvm2::utils::container::string_view{str.data(), str.size()}); }
+
+class raw_uwvm_string_ostream : public ::llvm::raw_ostream
+{
+    ::uwvm2::utils::container::string& output;
+
+    void write_impl(char const* ptr, ::std::size_t size) override { output.append(ptr, size); }
+
+    [[nodiscard]] ::std::uint64_t current_pos() const override { return output.size(); }
+
+public:
+    explicit raw_uwvm_string_ostream(::uwvm2::utils::container::string& str) : ::llvm::raw_ostream{true}, output{str} {}
+
+    void reserveExtraSpace(::std::uint64_t extra_size) override { output.reserve(static_cast<::std::size_t>(this->tell() + extra_size)); }
+};
+
 [[nodiscard]] inline constexpr ::std::uint_least8_t get_runtime_wasm_value_type_encoding(runtime_operand_stack_value_type value_type) noexcept
 { return static_cast<::std::uint_least8_t>(static_cast<::uwvm2::parser::wasm::standard::wasm1::type::wasm_byte>(value_type)); }
 
@@ -576,32 +596,40 @@ struct runtime_direct_callee_resolution_t
     }
 }
 
-[[nodiscard]] inline ::std::string get_llvm_runtime_module_symbol_prefix(::uwvm2::uwvm::runtime::storage::wasm_module_storage_t const& runtime_module)
-{ return ::std::string{"uwvm_m_"} + ::std::to_string(reinterpret_cast<::std::uintptr_t>(::std::addressof(runtime_module))); }
-
-[[nodiscard]] inline ::std::string get_llvm_wasm_function_name(::uwvm2::uwvm::runtime::storage::wasm_module_storage_t const& runtime_module,
-                                                               validation_module_traits_t::wasm_u32 func_index)
+[[nodiscard]] inline ::uwvm2::utils::container::string
+    get_llvm_runtime_module_symbol_prefix(::uwvm2::uwvm::runtime::storage::wasm_module_storage_t const& runtime_module)
 {
-    auto const func_index_uz{static_cast<::std::size_t>(func_index)};
-    return get_llvm_runtime_module_symbol_prefix(runtime_module) + "_func_" + ::std::to_string(func_index_uz);
+    return ::uwvm2::utils::container::concat_uwvm("uwvm_m_",
+                                                  reinterpret_cast<::std::uintptr_t>(::std::addressof(runtime_module)));
 }
 
-[[nodiscard]] inline ::std::string get_llvm_wasm_raw_function_name(::uwvm2::uwvm::runtime::storage::wasm_module_storage_t const& runtime_module,
-                                                                   validation_module_traits_t::wasm_u32 func_index)
+[[nodiscard]] inline ::uwvm2::utils::container::string
+    get_llvm_wasm_function_name(::uwvm2::uwvm::runtime::storage::wasm_module_storage_t const& runtime_module,
+                                validation_module_traits_t::wasm_u32 func_index)
 {
     auto const func_index_uz{static_cast<::std::size_t>(func_index)};
-    return get_llvm_runtime_module_symbol_prefix(runtime_module) + "_raw_func_" + ::std::to_string(func_index_uz);
+    return ::uwvm2::utils::container::concat_uwvm(get_llvm_runtime_module_symbol_prefix(runtime_module), "_func_", func_index_uz);
 }
 
-[[nodiscard]] inline ::std::string get_llvm_wasm_function_ir_module_name(::uwvm2::uwvm::runtime::storage::wasm_module_storage_t const& runtime_module,
-                                                                         validation_module_traits_t::wasm_u32 func_index)
+[[nodiscard]] inline ::uwvm2::utils::container::string
+    get_llvm_wasm_raw_function_name(::uwvm2::uwvm::runtime::storage::wasm_module_storage_t const& runtime_module,
+                                    validation_module_traits_t::wasm_u32 func_index)
 {
     auto const func_index_uz{static_cast<::std::size_t>(func_index)};
-    return get_llvm_runtime_module_symbol_prefix(runtime_module) + "_ir_module_for_func_" + ::std::to_string(func_index_uz);
+    return ::uwvm2::utils::container::concat_uwvm(get_llvm_runtime_module_symbol_prefix(runtime_module), "_raw_func_", func_index_uz);
 }
 
-[[nodiscard]] inline ::std::string get_llvm_wasm_ir_module_name(::uwvm2::uwvm::runtime::storage::wasm_module_storage_t const& runtime_module)
-{ return get_llvm_runtime_module_symbol_prefix(runtime_module) + "_ir_module"; }
+[[nodiscard]] inline ::uwvm2::utils::container::string
+    get_llvm_wasm_function_ir_module_name(::uwvm2::uwvm::runtime::storage::wasm_module_storage_t const& runtime_module,
+                                          validation_module_traits_t::wasm_u32 func_index)
+{
+    auto const func_index_uz{static_cast<::std::size_t>(func_index)};
+    return ::uwvm2::utils::container::concat_uwvm(get_llvm_runtime_module_symbol_prefix(runtime_module), "_ir_module_for_func_", func_index_uz);
+}
+
+[[nodiscard]] inline ::uwvm2::utils::container::string get_llvm_wasm_ir_module_name(
+    ::uwvm2::uwvm::runtime::storage::wasm_module_storage_t const& runtime_module)
+{ return ::uwvm2::utils::container::concat_uwvm(get_llvm_runtime_module_symbol_prefix(runtime_module), "_ir_module"); }
 
 [[nodiscard]] inline ::llvm::FunctionType*
     get_llvm_function_type_from_wasm_function_type(::llvm::LLVMContext& llvm_context,
@@ -618,11 +646,13 @@ struct runtime_direct_callee_resolution_t
     if(callee_function_type == nullptr) [[unlikely]] { return nullptr; }
 
     auto const callee_name{get_llvm_wasm_function_name(runtime_module, func_index)};
-    auto callee_function{llvm_module.getFunction(callee_name)};
+    auto callee_function{llvm_module.getFunction(get_llvm_string_ref(callee_name))};
     if(callee_function == nullptr)
     {
-        callee_function =
-            ::llvm::Function::Create(callee_function_type, ::llvm::Function::ExternalLinkage, callee_name, ::std::addressof(llvm_module));
+        callee_function = ::llvm::Function::Create(callee_function_type,
+                                                   ::llvm::Function::ExternalLinkage,
+                                                   get_llvm_string_ref(callee_name),
+                                                   ::std::addressof(llvm_module));
         apply_llvm_jit_wasm_calling_conv(*callee_function);
         return callee_function;
     }
@@ -2169,7 +2199,8 @@ struct runtime_local_func_llvm_jit_emit_state_t
     module_storage.llvm_context_holder = ::std::make_unique<::llvm::LLVMContext>();
     if(module_storage.llvm_context_holder == nullptr) [[unlikely]] { return false; }
 
-    module_storage.llvm_module = ::std::make_unique<::llvm::Module>(get_llvm_wasm_ir_module_name(runtime_module), *module_storage.llvm_context_holder);
+    auto const llvm_module_name{get_llvm_wasm_ir_module_name(runtime_module)};
+    module_storage.llvm_module = ::std::make_unique<::llvm::Module>(get_llvm_string_ref(llvm_module_name), *module_storage.llvm_context_holder);
     return module_storage.llvm_module != nullptr;
 }
 
@@ -2242,10 +2273,11 @@ struct runtime_local_func_llvm_jit_emit_state_t
 
     auto llvm_function_type{::llvm::FunctionType::get(llvm_result_type, llvm_parameter_types, false)};
     auto const function_name{get_llvm_wasm_function_name(*runtime_module_ptr, static_cast<validation_module_traits_t::wasm_u32>(local_func_storage.function_index))};
-    state.llvm_function = state.llvm_module->getFunction(function_name);
+    state.llvm_function = state.llvm_module->getFunction(get_llvm_string_ref(function_name));
     if(state.llvm_function == nullptr)
     {
-        state.llvm_function = ::llvm::Function::Create(llvm_function_type, ::llvm::Function::ExternalLinkage, function_name, state.llvm_module);
+        state.llvm_function =
+            ::llvm::Function::Create(llvm_function_type, ::llvm::Function::ExternalLinkage, get_llvm_string_ref(function_name), state.llvm_module);
     }
     else
     {
@@ -2370,11 +2402,14 @@ struct runtime_local_func_llvm_jit_emit_state_t
             if(raw_entry_function_type == nullptr) [[unlikely]] { return false; }
 
             auto const raw_entry_function_name{get_llvm_wasm_raw_function_name(*runtime_module_ptr, function_index)};
-            auto raw_entry_function{llvm_module->getFunction(raw_entry_function_name)};
+            auto raw_entry_function{llvm_module->getFunction(get_llvm_string_ref(raw_entry_function_name))};
             if(raw_entry_function == nullptr)
             {
                 raw_entry_function =
-                    ::llvm::Function::Create(raw_entry_function_type, ::llvm::Function::ExternalLinkage, raw_entry_function_name, llvm_module);
+                    ::llvm::Function::Create(raw_entry_function_type,
+                                             ::llvm::Function::ExternalLinkage,
+                                             get_llvm_string_ref(raw_entry_function_name),
+                                             llvm_module);
             }
             else
             {
@@ -2468,18 +2503,14 @@ struct runtime_local_func_llvm_jit_emit_state_t
 
             raw_ir_builder.CreateRetVoid();
 
-            ::std::string raw_verify_error{};
-            ::llvm::raw_string_ostream raw_verify_stream(raw_verify_error);
-            if(::llvm::verifyFunction(*raw_entry_function, ::std::addressof(raw_verify_stream))) [[unlikely]] { return false; }
+            if(::llvm::verifyFunction(*raw_entry_function)) [[unlikely]] { return false; }
             return true;
         }};
 
     if(!emit_runtime_local_func_llvm_jit_raw_entry_wrapper()) [[unlikely]] { return false; }
 
-    ::std::string verify_error{};
-    ::llvm::raw_string_ostream verify_stream(verify_error);
-    if(::llvm::verifyFunction(*state.llvm_function, ::std::addressof(verify_stream))) [[unlikely]] { return false; }
-    if(::llvm::verifyModule(*state.llvm_module, ::std::addressof(verify_stream))) [[unlikely]] { return false; }
+    if(::llvm::verifyFunction(*state.llvm_function)) [[unlikely]] { return false; }
+    if(::llvm::verifyModule(*state.llvm_module)) [[unlikely]] { return false; }
     return true;
 }
 

--- a/src/uwvm2/runtime/lib/uwvm_runtime.default.cpp
+++ b/src/uwvm2/runtime/lib/uwvm_runtime.default.cpp
@@ -3135,7 +3135,8 @@ namespace uwvm2::runtime::lib
         [[nodiscard]] inline bool runtime_compiler_requires_llvm_jit_execution() noexcept
         { return ::uwvm2::uwvm::runtime::runtime_mode::global_runtime_compiler == ::uwvm2::uwvm::runtime::runtime_mode::runtime_compiler_t::llvm_jit_only; }
 
-        [[nodiscard]] inline ::std::string get_runtime_llvm_jit_wasm_function_name(runtime_module_storage_t const& runtime_module, ::std::size_t func_index)
+        [[nodiscard]] inline ::uwvm2::utils::container::string
+            get_runtime_llvm_jit_wasm_function_name(runtime_module_storage_t const& runtime_module, ::std::size_t func_index)
         {
             namespace llvm_jit_translate_details = ::uwvm2::runtime::compiler::llvm_jit::compile_all_from_uwvm::details;
             return llvm_jit_translate_details::get_llvm_wasm_function_name(
@@ -3143,7 +3144,8 @@ namespace uwvm2::runtime::lib
                 static_cast<llvm_jit_translate_details::validation_module_traits_t::wasm_u32>(func_index));
         }
 
-        [[nodiscard]] inline ::std::string get_runtime_llvm_jit_wasm_raw_function_name(runtime_module_storage_t const& runtime_module, ::std::size_t func_index)
+        [[nodiscard]] inline ::uwvm2::utils::container::string
+            get_runtime_llvm_jit_wasm_raw_function_name(runtime_module_storage_t const& runtime_module, ::std::size_t func_index)
         {
             namespace llvm_jit_translate_details = ::uwvm2::runtime::compiler::llvm_jit::compile_all_from_uwvm::details;
             return llvm_jit_translate_details::get_llvm_wasm_raw_function_name(
@@ -3163,26 +3165,37 @@ namespace uwvm2::runtime::lib
             return success;
         }
 
-        [[nodiscard]] inline auto get_llvm_jit_host_target_attributes()
+        [[nodiscard]] inline ::uwvm2::utils::container::vector<::uwvm2::utils::container::string> get_llvm_jit_host_target_attribute_storage()
         {
-            ::llvm::SmallVector<::std::string, 16> mattrs{};
+            ::uwvm2::utils::container::vector<::uwvm2::utils::container::string> mattrs{};
             auto host_features{::llvm::sys::getHostCPUFeatures()};
             if(!host_features.empty())
             {
+                mattrs.reserve(host_features.size());
                 for(auto const& [feature_name, feature_enabled]: host_features)
                 {
                     auto prefix{feature_enabled ? '+' : '-'};
-                    mattrs.push_back(::std::string(1u, prefix) + feature_name.str());
+                    mattrs.push_back(::uwvm2::utils::container::concat_uwvm(
+                        prefix,
+                        ::uwvm2::utils::container::string_view{feature_name.data(), feature_name.size()}));
                 }
             }
             return mattrs;
         }
 
+        inline void append_llvm_jit_host_target_attribute_refs(
+            ::uwvm2::utils::container::vector<::uwvm2::utils::container::string> const& attr_storage,
+            ::llvm::SmallVector<::llvm::StringRef, 16>& attr_refs)
+        {
+            namespace llvm_jit_translate_details = ::uwvm2::runtime::compiler::llvm_jit::compile_all_from_uwvm::details;
+            attr_refs.clear();
+            attr_refs.reserve(attr_storage.size());
+            for(auto const& attr: attr_storage) { attr_refs.push_back(llvm_jit_translate_details::get_llvm_string_ref(attr)); }
+        }
+
         [[nodiscard]] inline bool optimize_runtime_llvm_jit_module(::llvm::Module& module, ::llvm::TargetMachine& target_machine) noexcept
         {
-            ::std::string verify_error{};
-            ::llvm::raw_string_ostream verify_stream(verify_error);
-            if(::llvm::verifyModule(module, ::std::addressof(verify_stream))) [[unlikely]] { return false; }
+            if(::llvm::verifyModule(module)) [[unlikely]] { return false; }
 
             ::llvm::legacy::FunctionPassManager function_pass_manager(::std::addressof(module));
             function_pass_manager.add(::llvm::createTargetTransformInfoWrapperPass(target_machine.getTargetIRAnalysis()));
@@ -3203,9 +3216,7 @@ namespace uwvm2::runtime::lib
             }
             function_pass_manager.doFinalization();
 
-            ::std::string optimized_verify_error{};
-            ::llvm::raw_string_ostream optimized_verify_stream(optimized_verify_error);
-            return !::llvm::verifyModule(module, ::std::addressof(optimized_verify_stream));
+            return !::llvm::verifyModule(module);
         }
 
         [[nodiscard]] inline bool try_materialize_runtime_module_llvm_jit(compiled_module_record& rec) noexcept
@@ -3288,33 +3299,28 @@ namespace uwvm2::runtime::lib
                 return false;
             }
 
-            auto const target_triple{::llvm::sys::getDefaultTargetTriple()};
-            auto const host_cpu_name{::llvm::sys::getHostCPUName().str()};
-            auto const host_target_attributes{get_llvm_jit_host_target_attributes()};
+            auto const host_cpu_name{::llvm::sys::getHostCPUName()};
+            auto const host_target_attribute_storage{get_llvm_jit_host_target_attribute_storage()};
+            ::llvm::SmallVector<::llvm::StringRef, 16> host_target_attributes{};
+            append_llvm_jit_host_target_attribute_refs(host_target_attribute_storage, host_target_attributes);
 
-            ::std::string engine_error{};
             ::llvm::EngineBuilder target_builder{};
-            target_builder.setErrorStr(::std::addressof(engine_error))
-                .setEngineKind(::llvm::EngineKind::JIT)
+            target_builder.setEngineKind(::llvm::EngineKind::JIT)
                 .setOptLevel(::llvm::CodeGenOptLevel::Aggressive)
                 .setMCPU(host_cpu_name)
                 .setMAttrs(host_target_attributes);
 
-            ::std::unique_ptr<::llvm::TargetMachine> target_machine{
-                target_builder.selectTarget(::llvm::Triple(target_triple), "", host_cpu_name, host_target_attributes)};
+            ::std::unique_ptr<::llvm::TargetMachine> target_machine{target_builder.selectTarget()};
             if(target_machine == nullptr) [[unlikely]]
             {
                 if(::uwvm2::uwvm::io::show_verbose) [[unlikely]]
                 {
-                    llvm_jit_materialize_error(u8"LLVM JIT target selection failed for module=\"",
-                                               rec.module_name,
-                                               u8"\": ",
-                                               ::fast_io::mnp::code_cvt(engine_error));
+                    llvm_jit_materialize_error(u8"LLVM JIT target selection failed for module=\"", rec.module_name, u8"\".");
                 }
                 return false;
             }
 
-            merged_module->setTargetTriple(::llvm::Triple(target_triple));
+            merged_module->setTargetTriple(target_machine->getTargetTriple());
             merged_module->setDataLayout(target_machine->createDataLayout());
             if(::uwvm2::uwvm::io::show_verbose) [[unlikely]]
             {
@@ -3335,7 +3341,6 @@ namespace uwvm2::runtime::lib
 
             auto raw_engine{::llvm::EngineBuilder(::std::move(merged_module))
                                 .setEngineKind(::llvm::EngineKind::JIT)
-                                .setErrorStr(::std::addressof(engine_error))
                                 .setOptLevel(::llvm::CodeGenOptLevel::Aggressive)
                                 .setMCPU(host_cpu_name)
                                 .setMAttrs(host_target_attributes)
@@ -3345,10 +3350,7 @@ namespace uwvm2::runtime::lib
             {
                 if(::uwvm2::uwvm::io::show_verbose) [[unlikely]]
                 {
-                    llvm_jit_materialize_error(u8"LLVM JIT engine creation failed for module=\"",
-                                               rec.module_name,
-                                               u8"\": ",
-                                               ::fast_io::mnp::code_cvt(engine_error));
+                    llvm_jit_materialize_error(u8"LLVM JIT engine creation failed for module=\"", rec.module_name, u8"\".");
                 }
                 return false;
             }
@@ -3370,18 +3372,27 @@ namespace uwvm2::runtime::lib
             for(::std::size_t local_index{}; local_index != local_func_count; ++local_index)
             {
                 auto const function_index{import_func_count + local_index};
-                auto const resolve_function_address{[&](::std::string const& function_name) noexcept -> ::std::uintptr_t
+                auto const resolve_function_address{[&](::uwvm2::utils::container::string const& function_name) noexcept -> ::std::uintptr_t
                                                     {
-                                                        auto const function_address{llvm_jit_engine->getFunctionAddress(function_name)};
-                                                        if(function_address != 0u) [[likely]] { return static_cast<::std::uintptr_t>(function_address); }
+                                                        namespace llvm_jit_translate_details =
+                                                            ::uwvm2::runtime::compiler::llvm_jit::compile_all_from_uwvm::details;
+                                                        auto found_function{
+                                                            llvm_jit_engine->FindFunctionNamed(llvm_jit_translate_details::get_llvm_string_ref(function_name))};
+                                                        if(found_function != nullptr && !found_function->isDeclaration()) [[likely]]
+                                                        {
+                                                            auto const function_address{llvm_jit_engine->getPointerToFunction(found_function)};
+                                                            if(function_address != nullptr) [[likely]]
+                                                            {
+                                                                return reinterpret_cast<::std::uintptr_t>(function_address);
+                                                            }
+                                                        }
 
                                                         if(::uwvm2::uwvm::io::show_verbose) [[unlikely]]
                                                         {
-                                                            auto found_function{llvm_jit_engine->FindFunctionNamed(function_name)};
-                                                            ::std::string function_type_text{};
+                                                            ::uwvm2::utils::container::string function_type_text{};
                                                             if(found_function != nullptr)
                                                             {
-                                                                ::llvm::raw_string_ostream function_type_stream(function_type_text);
+                                                                llvm_jit_translate_details::raw_uwvm_string_ostream function_type_stream(function_type_text);
                                                                 found_function->getFunctionType()->print(function_type_stream);
                                                             }
                                                             llvm_jit_materialize_error(u8"LLVM JIT could not resolve function address for module=\"",

--- a/src/uwvm2/utils/thread/native_thread.h
+++ b/src/uwvm2/utils/thread/native_thread.h
@@ -105,6 +105,8 @@ UWVM_MODULE_EXPORT namespace uwvm2::utils::thread
         {
             [[nodiscard]] inline constexpr scheduled_task get_return_object() noexcept { return scheduled_task{handle_type::from_promise(*this)}; }
 
+            [[nodiscard]] inline static constexpr scheduled_task get_return_object_on_allocation_failure() noexcept { return {}; }
+
             [[nodiscard]] inline constexpr ::std::suspend_always initial_suspend() const noexcept { return {}; }
 
             [[nodiscard]] inline constexpr ::std::suspend_always final_suspend() const noexcept { return {}; }
@@ -225,7 +227,7 @@ UWVM_MODULE_EXPORT namespace uwvm2::utils::thread
         inline constexpr native_thread_pool(native_thread_pool const&) noexcept = delete;
         inline constexpr native_thread_pool& operator= (native_thread_pool const&) noexcept = delete;
 
-        inline constexpr native_thread_pool(native_thread_pool&& other) noexcept
+        inline constexpr native_thread_pool([[maybe_unused]] native_thread_pool&& other) noexcept
 #ifdef UWVM_UTILS_HAS_FAST_IO_NATIVE_THREAD
             : workers{::std::move(other.workers)},
               worker_count{::std::exchange(other.worker_count, 0uz)}

--- a/src/uwvm2/uwvm/cmdline/callback/runtime_compile_threads.h
+++ b/src/uwvm2/uwvm/cmdline/callback/runtime_compile_threads.h
@@ -116,7 +116,7 @@ UWVM_MODULE_EXPORT namespace uwvm2::uwvm::cmdline::params::details
         using runtime_compile_threads_type = ::uwvm2::uwvm::runtime::runtime_mode::runtime_compile_threads_type;
         using runtime_compile_threads_policy_t = ::uwvm2::uwvm::runtime::runtime_mode::runtime_compile_threads_policy_t;
 
-        runtime_compile_threads_type compile_threads;  // No initialization necessary
+        runtime_compile_threads_type compile_threads{};
         auto const [next, err]{::fast_io::parse_by_scan(currp1_str.cbegin(), currp1_str.cend(), compile_threads)};
 
         if(err == ::fast_io::parse_code::ok && next == currp1_str.cend())

--- a/src/uwvm2/uwvm/cmdline/callback/wasip1_global_trace.h
+++ b/src/uwvm2/uwvm/cmdline/callback/wasip1_global_trace.h
@@ -91,7 +91,7 @@ UWVM_MODULE_EXPORT namespace uwvm2::uwvm::cmdline::params::details
 
         [[nodiscard]] inline parameter_return_type apply_trace_target_to_default_env(
             ::uwvm2::utils::cmdline::parameter_parsing_results* target_arg,
-            ::uwvm2::utils::cmdline::parameter_parsing_results* para_end) noexcept
+            [[maybe_unused]] ::uwvm2::utils::cmdline::parameter_parsing_results* para_end) noexcept
         {
             auto& env{::uwvm2::uwvm::imported::wasi::wasip1::storage::default_wasip1_env};
             auto const target_text{::uwvm2::utils::container::u8string_view{target_arg->str}};

--- a/src/uwvm2/uwvm/crtmain/uwvm.h
+++ b/src/uwvm2/uwvm/crtmain/uwvm.h
@@ -151,8 +151,10 @@ UWVM_MODULE_EXPORT namespace uwvm2::uwvm
         using char8_t_const_ptr_const_may_alias_ptr UWVM_GNU_MAY_ALIAS = char8_t const* const*;
         auto const argv_u8{reinterpret_cast<char8_t_const_ptr_const_may_alias_ptr>(argv)};
 
-        // fast_io network servive (on win9x = wsa, on linux = dummy)
+#if defined(_WIN32) || (!defined(__wasi__) && __has_include(<sys/socket.h>) && __has_include(<netinet/in.h>))
+        // fast_io network service (on win9x = wsa, on linux = dummy)
         ::fast_io::net_service service{};
+#endif
 
         // u8main
         return uwvm_uz_u8main(argc_uz, argv_u8);
@@ -185,8 +187,10 @@ UWVM_MODULE_EXPORT namespace uwvm2::uwvm
         auto const argc_uz{u8_cmdline.argc};
         auto const argv_u8{u8_cmdline.argv.data()};
 
-        // fast_io network servive
+#if defined(_WIN32) || (!defined(__wasi__) && __has_include(<sys/socket.h>) && __has_include(<netinet/in.h>))
+        // fast_io network service
         ::fast_io::net_service service{};
+#endif
 
         // u8main
         return uwvm_uz_u8main(argc_uz, argv_u8);

--- a/third-parties/boost_unordered/include/boost/core/detail/sp_thread_sleep.hpp
+++ b/third-parties/boost_unordered/include/boost/core/detail/sp_thread_sleep.hpp
@@ -26,7 +26,7 @@
   BOOST_PRAGMA_MESSAGE("Using Sleep(1) in sp_thread_sleep")
 #endif
 
-#include "/sp_win32_sleep.hpp"
+#include "sp_win32_sleep.hpp"
 
 namespace boost
 {
@@ -101,7 +101,7 @@ inline void sp_thread_sleep() noexcept
   BOOST_PRAGMA_MESSAGE("Using sp_thread_yield() in sp_thread_sleep")
 #endif
 
-#include "/sp_thread_yield.hpp"
+#include "sp_thread_yield.hpp"
 
 namespace boost
 {

--- a/third-parties/boost_unordered/include/boost/core/detail/sp_thread_yield.hpp
+++ b/third-parties/boost_unordered/include/boost/core/detail/sp_thread_yield.hpp
@@ -26,7 +26,7 @@
   BOOST_PRAGMA_MESSAGE("Using SwitchToThread() in sp_thread_yield")
 #endif
 
-#include "/sp_win32_sleep.hpp"
+#include "sp_win32_sleep.hpp"
 
 namespace boost
 {
@@ -83,7 +83,7 @@ inline void sp_thread_yield() noexcept
   BOOST_PRAGMA_MESSAGE("Using sp_thread_pause() in sp_thread_yield")
 #endif
 
-#include "/sp_thread_pause.hpp"
+#include "sp_thread_pause.hpp"
 
 namespace boost
 {

--- a/third-parties/boost_unordered/include/boost/minconfig.hpp
+++ b/third-parties/boost_unordered/include/boost/minconfig.hpp
@@ -128,10 +128,13 @@
 #endif
 
 #define BOOST_HAS_NRVO
+
+#if !defined(__DJGPP__) && !defined(__MSDOS__)
 #define BOOST_HAS_THREADS
 
 #if !defined(_MSC_VER)
 #define BOOST_HAS_PTHREADS
 #define BOOST_HAS_NANOSLEEP
 #define BOOST_HAS_SCHED_YIELD
+#endif
 #endif

--- a/xmake/platform/djgpp.lua
+++ b/xmake/platform/djgpp.lua
@@ -34,6 +34,7 @@ function djgpp_target()
     end
 
     add_cxflags("-fno-rtti") -- disable rtti
+    add_cxflags("-Wno-maybe-musttail-local-addr", {force = true})
     
     if not is_mode("debug") then
         add_cxflags("-fno-unwind-tables") -- disable unwind tables


### PR DESCRIPTION
- Removed unnecessary string includes from translation files to streamline dependencies.
- Introduced `get_llvm_string_ref` functions to convert custom string types to LLVM's `StringRef`, enhancing type safety and consistency.
- Updated function signatures across the codebase to utilize the new string handling methods, improving clarity and maintainability.
- Enhanced memory management in the LLVM JIT by replacing `std::string` with `uwvm2::utils::container::string` for better integration with custom container types.